### PR TITLE
ActionWhenThresholdReached missing doublequote

### DIFF
--- a/Exchange Online/Baseline-M365BTenant.ps1
+++ b/Exchange Online/Baseline-M365BTenant.ps1
@@ -300,8 +300,9 @@ if ($Answer -eq 'y' -or $Answer -eq 'yes') {
                 "Identity" = 'Default';
                 'RecipientLimitExternalPerHour' = 500;
                 'RecipientLimitInternalPerHour' = 1000;
-                'ActionWhenThresholdReached' = BlockUserForToday;
-                'notifyoutboundspam' = $true;
+                'RecipientLimitPerDay' = 1000;
+                'ActionWhenThresholdReached' = "BlockUser";
+		'notifyoutboundspam' = $true;
                 'NotifyOutboundSpamRecipients' = $AlertAddress
             }
             Set-HostedOutboundSpamFilterPolicy @OutboundPolicyParam


### PR DESCRIPTION
Changed option of ActionWhenThresholdReached for BlockUserToday to BlockUser because this is standard setting now. And added RecipientLimitPerDay with the default of 1000.