### PR TITLE
Fix issue with existing "Exclude from CA" group not found

### DIFF
--- a/Azure AD/Baseline-ConditionalAccessPolicies.ps1
+++ b/Azure AD/Baseline-ConditionalAccessPolicies.ps1
@@ -36,14 +36,15 @@
 ## Check for the existence of the "Exclude from CA" security group, and create the group if it does not exist
 
 $ExcludeCAGroupName = "Exclude From CA"
-$ExcludeCAGroup = Get-AzureADGroup -All $true | Where-Object DisplayName -EQ $ExcludeCAGroupName
+$ExcludeCAGroup = Get-AzureADGroup -All $true | Where-Object DisplayName -eq $ExcludeCAGroupName
 
 if ($ExcludeCAGroup -eq $null -or $ExcludeCAGroup -eq "") {
-New-AzureADGroup -DisplayName $ExcludeCAGroupName -SecurityEnabled $true -MailEnabled $false -MailNickName ExcludeFromCA
-$ExcludeCAGroup = Get-AzureADGroup -All $true | Where-Object DisplayName -EQ $ExcludeCAGroupName
-
+	New-AzureADGroup -DisplayName $ExcludeCAGroupName -SecurityEnabled $true -MailEnabled $false -MailNickName ExcludeFromCA
+	$ExcludeCAGroup = Get-AzureADGroup -All $true | Where-Object DisplayName -eq $ExcludeCAGroupName
 }
-else {write-host "Exclude from CA group already exists"}
+else {
+	Write-Host "Exclude from CA group already exists"
+}
 
 
 ########################################################

--- a/Azure AD/Baseline-ConditionalAccessPolicies.ps1
+++ b/Azure AD/Baseline-ConditionalAccessPolicies.ps1
@@ -35,11 +35,12 @@
 
 ## Check for the existence of the "Exclude from CA" security group, and create the group if it does not exist
 
-$ExcludeCAGroup = Get-AzureADGroup -All $true | Where-Object DisplayName -EQ "Exclude From CA"
+$ExcludeCAGroupName = "Exclude From CA"
+$ExcludeCAGroup = Get-AzureADGroup -All $true | Where-Object DisplayName -EQ $ExcludeCAGroupName
 
 if ($ExcludeCAGroup -eq $null -or $ExcludeCAGroup -eq "") {
-New-AzureADGroup -DisplayName "Exclude From CA" -SecurityEnabled $true -MailEnabled $false -MailNickName ExludeFromCA
-$ExcludeCAGroup = Get-AzureADGroup -All $true | Where-Object DisplayName -EQ "Exclude From CA"
+New-AzureADGroup -DisplayName $ExcludeCAGroupName -SecurityEnabled $true -MailEnabled $false -MailNickName ExludeFromCA
+$ExcludeCAGroup = Get-AzureADGroup -All $true | Where-Object DisplayName -EQ $ExcludeCAGroupName
 
 }
 else {write-host "Exclude from CA group already exists"}

--- a/Azure AD/Baseline-ConditionalAccessPolicies.ps1
+++ b/Azure AD/Baseline-ConditionalAccessPolicies.ps1
@@ -39,7 +39,7 @@ $ExcludeCAGroupName = "Exclude From CA"
 $ExcludeCAGroup = Get-AzureADGroup -All $true | Where-Object DisplayName -EQ $ExcludeCAGroupName
 
 if ($ExcludeCAGroup -eq $null -or $ExcludeCAGroup -eq "") {
-New-AzureADGroup -DisplayName $ExcludeCAGroupName -SecurityEnabled $true -MailEnabled $false -MailNickName ExludeFromCA
+New-AzureADGroup -DisplayName $ExcludeCAGroupName -SecurityEnabled $true -MailEnabled $false -MailNickName ExcludeFromCA
 $ExcludeCAGroup = Get-AzureADGroup -All $true | Where-Object DisplayName -EQ $ExcludeCAGroupName
 
 }

--- a/Azure AD/Baseline-ConditionalAccessPolicies.ps1
+++ b/Azure AD/Baseline-ConditionalAccessPolicies.ps1
@@ -35,11 +35,11 @@
 
 ## Check for the existence of the "Exclude from CA" security group, and create the group if it does not exist
 
-$ExcludeCAGroup = Get-AzureADGroup | Where-Object DisplayName -EQ "Exclude From CA"
+$ExcludeCAGroup = Get-AzureADGroup -All $true | Where-Object DisplayName -EQ "Exclude From CA"
 
 if ($ExcludeCAGroup -eq $null -or $ExcludeCAGroup -eq "") {
 New-AzureADGroup -DisplayName "Exclude From CA" -SecurityEnabled $true -MailEnabled $false -MailNickName ExludeFromCA
-$ExcludeCAGroup = Get-AzureADGroup | Where-Object DisplayName -EQ "Exclude From CA"
+$ExcludeCAGroup = Get-AzureADGroup -All $true | Where-Object DisplayName -EQ "Exclude From CA"
 
 }
 else {write-host "Exclude from CA group already exists"}

--- a/Azure AD/Baseline-ConditionalAccessPolicies.ps1
+++ b/Azure AD/Baseline-ConditionalAccessPolicies.ps1
@@ -27,7 +27,7 @@
     FileName:    Baseline-ConditionalAccessPolicies.ps1
     Author:      Alex Fields, ITProMentor.com
     Created:     September 2020
-	Updated:     October 2020
+    Updated:     October 2020
 
 #>
 ###################################################################################################
@@ -39,11 +39,11 @@ $ExcludeCAGroupName = "Exclude From CA"
 $ExcludeCAGroup = Get-AzureADGroup -All $true | Where-Object DisplayName -eq $ExcludeCAGroupName
 
 if ($ExcludeCAGroup -eq $null -or $ExcludeCAGroup -eq "") {
-	New-AzureADGroup -DisplayName $ExcludeCAGroupName -SecurityEnabled $true -MailEnabled $false -MailNickName ExcludeFromCA
-	$ExcludeCAGroup = Get-AzureADGroup -All $true | Where-Object DisplayName -eq $ExcludeCAGroupName
+    New-AzureADGroup -DisplayName $ExcludeCAGroupName -SecurityEnabled $true -MailEnabled $false -MailNickName ExcludeFromCA
+    $ExcludeCAGroup = Get-AzureADGroup -All $true | Where-Object DisplayName -eq $ExcludeCAGroupName
 }
 else {
-	Write-Host "Exclude from CA group already exists"
+    Write-Host "Exclude from CA group already exists"
 }
 
 


### PR DESCRIPTION
* Use `Get-AzureADGroup -All $true` to fix #12: "Existing "Exclude from CA" group not found"
* Extract "Exclude from CA" group name to variable
* Fix typo in MailNickName
* Minor tweaks to code formatting and indentation 