### PR TITLE
Added check for existing policy so script can be ran multiple times

### DIFF
--- a/Azure AD/Baseline-ConditionalAccessPolicies.ps1
+++ b/Azure AD/Baseline-ConditionalAccessPolicies.ps1
@@ -44,77 +44,105 @@ else {
     Write-Host "Exclude from CA group already exists"
 }
 
+## Get list of existing policies for checking later.
+
+$ExistingPolicies = Get-AzureADMSConditionalAccessPolicy | Select-Object DisplayName
+
 ########################################################
 
 ## This policy blocks legacy authentication for all users
 
-$conditions = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessConditionSet
-$conditions.Applications = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessApplicationCondition
-$conditions.Applications.IncludeApplications = "All"
-$conditions.Users = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessUserCondition
-$conditions.Users.IncludeUsers = "All"
-$conditions.Users.ExcludeGroups = $ExcludeCAGroup.ObjectId
-$conditions.ClientAppTypes = @('ExchangeActiveSync', 'Other')
-$controls = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessGrantControls
-$controls._Operator = "OR"
-$controls.BuiltInControls = "Block"
+$displayName = "[All cloud apps] BLOCK: Legacy authentication clients"
+if ($ExistingPolicies.DisplayName -contains $displayName) {
+    Write-Host "Policy '$displayName' already exists."
+}
+else {
+    $conditions = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessConditionSet
+    $conditions.Applications = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessApplicationCondition
+    $conditions.Applications.IncludeApplications = "All"
+    $conditions.Users = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessUserCondition
+    $conditions.Users.IncludeUsers = "All"
+    $conditions.Users.ExcludeGroups = $ExcludeCAGroup.ObjectId
+    $conditions.ClientAppTypes = @('ExchangeActiveSync', 'Other')
+    $controls = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessGrantControls
+    $controls._Operator = "OR"
+    $controls.BuiltInControls = "Block"
 
-New-AzureADMSConditionalAccessPolicy -DisplayName "[All cloud apps] BLOCK: Legacy authentication clients" -State "Disabled" -Conditions $conditions -GrantControls $controls 
+    New-AzureADMSConditionalAccessPolicy -DisplayName $displayName -State "Disabled" -Conditions $conditions -GrantControls $controls 
+}
 
 ########################################################
 
 ## This policy requires Multi-factor authentication for Admin users
 
-$conditions = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessConditionSet
-$conditions.Applications = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessApplicationCondition
-$conditions.Applications.IncludeApplications = "All"
-$conditions.Users = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessUserCondition
-$conditions.Users.IncludeRoles = @('62e90394-69f5-4237-9190-012177145e10', 'f28a1f50-f6e7-4571-818b-6a12f2af6b6c', '29232cdf-9323-42fd-ade2-1d097af3e4de', 'b1be1c3e-b65d-4f19-8427-f6fa0d97feb9', '194ae4cb-b126-40b2-bd5b-6091b380977d', '729827e3-9c14-49f7-bb1b-9608f156bbb8', '966707d0-3269-4727-9be2-8c3a10f19b9d', 'b0f54661-2d74-4c50-afa3-1ec803f12efe', 'fe930be7-5e62-47db-91af-98c3a49a38b1')
-$conditions.Users.ExcludeGroups = $ExcludeCAGroup.ObjectId
-$conditions.ClientAppTypes = @('Browser', 'MobileAppsAndDesktopClients')
-$controls = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessGrantControls
-$controls._Operator = "OR"
-$controls.BuiltInControls = "MFA"
+$displayName = "[All cloud apps] GRANT: Require MFA for Admin users"
+if ($ExistingPolicies.DisplayName -contains $displayName) {
+    Write-Host "Policy '$displayName' already exists."
+}
+else {
+    $conditions = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessConditionSet
+    $conditions.Applications = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessApplicationCondition
+    $conditions.Applications.IncludeApplications = "All"
+    $conditions.Users = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessUserCondition
+    $conditions.Users.IncludeRoles = @('62e90394-69f5-4237-9190-012177145e10', 'f28a1f50-f6e7-4571-818b-6a12f2af6b6c', '29232cdf-9323-42fd-ade2-1d097af3e4de', 'b1be1c3e-b65d-4f19-8427-f6fa0d97feb9', '194ae4cb-b126-40b2-bd5b-6091b380977d', '729827e3-9c14-49f7-bb1b-9608f156bbb8', '966707d0-3269-4727-9be2-8c3a10f19b9d', 'b0f54661-2d74-4c50-afa3-1ec803f12efe', 'fe930be7-5e62-47db-91af-98c3a49a38b1')
+    $conditions.Users.ExcludeGroups = $ExcludeCAGroup.ObjectId
+    $conditions.ClientAppTypes = @('Browser', 'MobileAppsAndDesktopClients')
+    $controls = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessGrantControls
+    $controls._Operator = "OR"
+    $controls.BuiltInControls = "MFA"
 
-New-AzureADMSConditionalAccessPolicy -DisplayName "[All cloud apps] GRANT: Require MFA for Admin users" -State "Disabled" -Conditions $conditions -GrantControls $controls 
+    New-AzureADMSConditionalAccessPolicy -DisplayName $displayName -State "Disabled" -Conditions $conditions -GrantControls $controls 
+}
 
 ########################################################
 
 ## This policy requires Multi-factor authentication for All users
 
-$conditions = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessConditionSet
-$conditions.Applications = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessApplicationCondition
-$conditions.Applications.IncludeApplications = "All"
-$conditions.Users = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessUserCondition
-$conditions.Users.IncludeUsers = "All"
-$conditions.Users.ExcludeUsers = "GuestsOrExternalUsers"
-$conditions.Users.ExcludeGroups = $ExcludeCAGroup.ObjectId
-$conditions.ClientAppTypes = @('Browser', 'MobileAppsAndDesktopClients')
-$controls = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessGrantControls
-$controls._Operator = "OR"
-$controls.BuiltInControls = "MFA"
+$displayName = "[All cloud apps] GRANT: Require MFA for All users"
+if ($ExistingPolicies.DisplayName -contains $displayName) {
+    Write-Host "Policy '$displayName' already exists."
+}
+else {
+    $conditions = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessConditionSet
+    $conditions.Applications = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessApplicationCondition
+    $conditions.Applications.IncludeApplications = "All"
+    $conditions.Users = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessUserCondition
+    $conditions.Users.IncludeUsers = "All"
+    $conditions.Users.ExcludeUsers = "GuestsOrExternalUsers"
+    $conditions.Users.ExcludeGroups = $ExcludeCAGroup.ObjectId
+    $conditions.ClientAppTypes = @('Browser', 'MobileAppsAndDesktopClients')
+    $controls = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessGrantControls
+    $controls._Operator = "OR"
+    $controls.BuiltInControls = "MFA"
 
-New-AzureADMSConditionalAccessPolicy -DisplayName "[All cloud apps] GRANT: Require MFA for All users" -State "Disabled" -Conditions $conditions -GrantControls $controls 
+    New-AzureADMSConditionalAccessPolicy -DisplayName $displayName -State "Disabled" -Conditions $conditions -GrantControls $controls 
+}
 
 ########################################################
 
 ## This policy blocks unsupported device platforms such as Linux and ChromeOS
 
-$conditions = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessConditionSet
-$conditions.Applications = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessApplicationCondition
-$conditions.Applications.IncludeApplications = "All"
-$conditions.Users = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessUserCondition
-$conditions.Users.IncludeUsers = "All"
-$conditions.Users.ExcludeUsers = "GuestsOrExternalUsers"
-$conditions.Users.ExcludeGroups = $ExcludeCAGroup.ObjectId
-$conditions.Platforms = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessPlatformCondition
-$conditions.Platforms.IncludePlatforms = "All"
-$conditions.Platforms.ExcludePlatforms = @('Android', 'IOS', 'Windows', 'macOS')
-$controls = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessGrantControls
-$controls._Operator = "OR"
-$controls.BuiltInControls = "Block"
+$displayName = "[All cloud apps] BLOCK: Device platforms such as Linux and ChromeOS"
+if ($ExistingPolicies.DisplayName -contains $displayName) {
+    Write-Host "Policy '$displayName' already exists."
+}
+else {
+    $conditions = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessConditionSet
+    $conditions.Applications = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessApplicationCondition
+    $conditions.Applications.IncludeApplications = "All"
+    $conditions.Users = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessUserCondition
+    $conditions.Users.IncludeUsers = "All"
+    $conditions.Users.ExcludeUsers = "GuestsOrExternalUsers"
+    $conditions.Users.ExcludeGroups = $ExcludeCAGroup.ObjectId
+    $conditions.Platforms = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessPlatformCondition
+    $conditions.Platforms.IncludePlatforms = "All"
+    $conditions.Platforms.ExcludePlatforms = @('Android', 'IOS', 'Windows', 'macOS')
+    $controls = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessGrantControls
+    $controls._Operator = "OR"
+    $controls.BuiltInControls = "Block"
 
-New-AzureADMSConditionalAccessPolicy -DisplayName "[All cloud apps] BLOCK: Device platforms such as Linux and ChromeOS" -State "Disabled" -Conditions $conditions -GrantControls $controls 
+    New-AzureADMSConditionalAccessPolicy -DisplayName $displayName -State "Disabled" -Conditions $conditions -GrantControls $controls 
+}
 
 ########################################################
 
@@ -123,21 +151,27 @@ New-AzureADMSConditionalAccessPolicy -DisplayName "[All cloud apps] BLOCK: Devic
 ##     1. End-users will not be able to access company data from built-in browser or mail apps for iOS or Android; they must use approved apps (e.g. Outlook, Edge)
 ##     2. Android and iOS users must have the Authenticator app configured, and Android users must also download the Company Portal app
 
-$conditions = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessConditionSet
-$conditions.Applications = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessApplicationCondition
-$conditions.Applications.IncludeApplications = "Office365"
-$conditions.Users = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessUserCondition
-$conditions.Users.IncludeUsers = "All"
-$conditions.Users.ExcludeUsers = "GuestsOrExternalUsers"
-$conditions.Users.ExcludeGroups = $ExcludeCAGroup.ObjectId
-$conditions.Platforms = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessPlatformCondition
-$conditions.Platforms.IncludePlatforms = @('Android', 'IOS')
-$conditions.ClientAppTypes = @('Browser', 'MobileAppsAndDesktopClients')
-$controls = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessGrantControls
-$controls._Operator = "OR"
-$controls.BuiltInControls = @('ApprovedApplication', 'CompliantApplication')
+$displayName = "[Office 365] GRANT: Require approved apps for mobile access (MAM)"
+if ($ExistingPolicies.DisplayName -contains $displayName) {
+    Write-Host "Policy '$displayName' already exists."
+}
+else {
+    $conditions = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessConditionSet
+    $conditions.Applications = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessApplicationCondition
+    $conditions.Applications.IncludeApplications = "Office365"
+    $conditions.Users = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessUserCondition
+    $conditions.Users.IncludeUsers = "All"
+    $conditions.Users.ExcludeUsers = "GuestsOrExternalUsers"
+    $conditions.Users.ExcludeGroups = $ExcludeCAGroup.ObjectId
+    $conditions.Platforms = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessPlatformCondition
+    $conditions.Platforms.IncludePlatforms = @('Android', 'IOS')
+    $conditions.ClientAppTypes = @('Browser', 'MobileAppsAndDesktopClients')
+    $controls = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessGrantControls
+    $controls._Operator = "OR"
+    $controls.BuiltInControls = @('ApprovedApplication', 'CompliantApplication')
 
-New-AzureADMSConditionalAccessPolicy -DisplayName "[Office 365] GRANT: Require approved apps for mobile access (MAM)" -State "Disabled" -Conditions $conditions -GrantControls $controls 
+    New-AzureADMSConditionalAccessPolicy -DisplayName $displayName -State "Disabled" -Conditions $conditions -GrantControls $controls 
+}
 
 ########################################################
 
@@ -150,21 +184,27 @@ New-AzureADMSConditionalAccessPolicy -DisplayName "[Office 365] GRANT: Require a
 ##    5. Optionally, you may add Android and IOS from the IncludePlatforms condition (if you want both MAM and MDM for mobile)
 ##    6. Optionally, you may add 'Browser' to the ClientAppTypes condition in lieu of the next policy (SESSION policy)
 
-$conditions = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessConditionSet
-$conditions.Applications = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessApplicationCondition
-$conditions.Applications.IncludeApplications = "Office365"
-$conditions.Users = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessUserCondition
-$conditions.Users.IncludeUsers = "All"
-$conditions.Users.ExcludeUsers = "GuestsOrExternalUsers"
-$conditions.Users.ExcludeGroups = $ExcludeCAGroup.ObjectId
-$conditions.Platforms = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessPlatformCondition
-$conditions.Platforms.IncludePlatforms = @('Windows', 'macOS')
-$conditions.ClientAppTypes = @('MobileAppsAndDesktopClients')
-$controls = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessGrantControls
-$controls._Operator = "OR"
-$controls.BuiltInControls = @('DomainJoinedDevice', 'CompliantDevice')
+$displayName = "[Office 365] GRANT: Require managed devices for Windows & MacOS (MDM)"
+if ($ExistingPolicies.DisplayName -contains $displayName) {
+    Write-Host "Policy '$displayName' already exists."
+}
+else {
+    $conditions = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessConditionSet
+    $conditions.Applications = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessApplicationCondition
+    $conditions.Applications.IncludeApplications = "Office365"
+    $conditions.Users = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessUserCondition
+    $conditions.Users.IncludeUsers = "All"
+    $conditions.Users.ExcludeUsers = "GuestsOrExternalUsers"
+    $conditions.Users.ExcludeGroups = $ExcludeCAGroup.ObjectId
+    $conditions.Platforms = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessPlatformCondition
+    $conditions.Platforms.IncludePlatforms = @('Windows', 'macOS')
+    $conditions.ClientAppTypes = @('MobileAppsAndDesktopClients')
+    $controls = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessGrantControls
+    $controls._Operator = "OR"
+    $controls.BuiltInControls = @('DomainJoinedDevice', 'CompliantDevice')
 
-New-AzureADMSConditionalAccessPolicy -DisplayName "[Office 365] GRANT: Require managed devices for Windows & MacOS (MDM)" -State "Disabled" -Conditions $conditions -GrantControls $controls 
+    New-AzureADMSConditionalAccessPolicy -DisplayName $displayName -State "Disabled" -Conditions $conditions -GrantControls $controls 
+}
 
 ########################################################
 
@@ -175,17 +215,23 @@ New-AzureADMSConditionalAccessPolicy -DisplayName "[Office 365] GRANT: Require m
 ##     3. Unmanaged browsers (e.g. Firefox) will also be impacted by this policy, even on managed devices
 ##     4. End users should be advised to use Edge (Chromium version) with Office 365
 
-$conditions = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessConditionSet
-$conditions.Applications = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessApplicationCondition
-$conditions.Applications.IncludeApplications = "Office365"
-$conditions.Users = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessUserCondition
-$conditions.Users.IncludeUsers = "All"
-$conditions.Users.ExcludeUsers = "GuestsOrExternalUsers"
-$conditions.Users.ExcludeGroups = $ExcludeCAGroup.ObjectId
-$conditions.ClientAppTypes = @('Browser')
-$controls = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessSessionControls
-$controls.ApplicationEnforcedRestrictions = $true
+$displayName = "[Office 365] SESSION: Prevent web downloads from unmanaged devices"
+if ($ExistingPolicies.DisplayName -contains $displayName) {
+    Write-Host "Policy '$displayName' already exists."
+}
+else {
+    $conditions = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessConditionSet
+    $conditions.Applications = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessApplicationCondition
+    $conditions.Applications.IncludeApplications = "Office365"
+    $conditions.Users = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessUserCondition
+    $conditions.Users.IncludeUsers = "All"
+    $conditions.Users.ExcludeUsers = "GuestsOrExternalUsers"
+    $conditions.Users.ExcludeGroups = $ExcludeCAGroup.ObjectId
+    $conditions.ClientAppTypes = @('Browser')
+    $controls = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessSessionControls
+    $controls.ApplicationEnforcedRestrictions = $true
 
-New-AzureADMSConditionalAccessPolicy -DisplayName "[Office 365] SESSION: Prevent web downloads from unmanaged devices" -State "Disabled" -Conditions $conditions -SessionControls $controls 
+    New-AzureADMSConditionalAccessPolicy -DisplayName $displayName -State "Disabled" -Conditions $conditions -SessionControls $controls 
+}
 
 ########################################################


### PR DESCRIPTION
Possible example ref #16 to add support for checking if policies exist first, allowing script to be ran multiple times if needed without re-creating existing policies.