### PR TITLE
Update Configure-Auditing.ps1

### DIFF
--- a/Exchange Online/Configure-Auditing.ps1
+++ b/Exchange Online/Configure-Auditing.ps1
@@ -44,7 +44,7 @@ if ($Answer -eq 'y' -or $Answer -eq 'yes') {
             Write-Host 
             Write-Host -ForegroundColor $MessageColor "The new audit log age limit has been set for all mailboxes"
             ## Enable all mailbox auditing actions
-            Get-Mailbox -ResultSize Unlimited | Set-Mailbox -AuditAdmin @{Add="Copy","Create","FolderBind","HardDelete","MessageBind","Move","MoveToDeletedItems","SendAs","SendOnBehalf","SoftDelete","Update","UpdateFolderPermissions","UpdateInboxRules","UpdateCalendarDelegation"}
+            Get-Mailbox -ResultSize Unlimited | Set-Mailbox -AuditAdmin @{Add="Copy","Create","FolderBind","HardDelete","MailItemsAccessed","Move","MoveToDeletedItems","SendAs","SendOnBehalf","SoftDelete","Update","UpdateFolderPermissions","UpdateInboxRules","UpdateCalendarDelegation"}
             Get-Mailbox -ResultSize Unlimited | Set-Mailbox –AuditDelegate @{Add="Create","FolderBind","HardDelete","Move","MoveToDeletedItems","SendAs","SendOnBehalf","SoftDelete","Update","UpdateFolderPermissions","UpdateInboxRules"}
             Get-Mailbox -ResultSize Unlimited | Set-Mailbox –AuditOwner @{Add="Create","HardDelete","Move","Mailboxlogin","MoveToDeletedItems","SoftDelete","Update","UpdateFolderPermissions","UpdateInboxRules","UpdateCalendarDelegation"}
             Write-Host 


### PR DESCRIPTION
Error with depreciated Audit Operation Type:

Write-ErrorMessage : 
|Microsoft.Exchange.Management.Tasks.RecipientTaskException|MessageBind audit operation  type is deprecated. Use MailItemsAccessed audit operation type instead.

Replaced MessageBind with MailItemsAccessed